### PR TITLE
inject the manifest document

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ changelog:
 # Homebrew
 brews:
   -
-    github:
+    tap:
       owner: sampointer
       name: homebrew-digaz
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/sampointer/digaz/command"
+	"github.com/sampointer/digaz/fetcher"
 )
 
 var cfgFile string
@@ -40,8 +41,14 @@ you to look up details of any specific IP address.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
+		doc, err := fetcher.Fetch()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
 		for _, arg := range args {
-			res, err := command.Lookup(arg)
+			res, err := command.Lookup(arg, &doc)
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/command/lookup.go
+++ b/command/lookup.go
@@ -1,22 +1,17 @@
 package command
 
 import (
-	"github.com/sampointer/digaz/fetcher"
 	"github.com/sampointer/digaz/servicetags"
 
+	"io"
 	"net"
 )
 
 //Lookup returns Property the AddressPrefixes of which include the passed IP
 //address
-func Lookup(q string) ([]servicetags.Property, error) {
+func Lookup(q string, doc *io.Reader) ([]servicetags.Property, error) {
 	var properties []servicetags.Property
-	doc, err := fetcher.Fetch()
-	if err != nil {
-		return properties, err
-	}
-
-	st, err := servicetags.New(doc)
+	st, err := servicetags.New(*doc)
 	if err != nil {
 		return properties, err
 	}

--- a/command/lookup_test.go
+++ b/command/lookup_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/sampointer/digaz/fetcher"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +15,9 @@ func TestLookup(t *testing.T) {
 	t.Run("looks up IPv4 address", func(t *testing.T) {
 		t.Parallel()
 
-		p, err := Lookup(ipv4)
+		doc, err := fetcher.Fetch()
+		require.NoError(t, err)
+		p, err := Lookup(ipv4, &doc)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(p))
 	})
@@ -22,7 +25,9 @@ func TestLookup(t *testing.T) {
 	t.Run("looks up IPv6 address", func(t *testing.T) {
 		t.Parallel()
 
-		p, err := Lookup(ipv6)
+		doc, err := fetcher.Fetch()
+		require.NoError(t, err)
+		p, err := Lookup(ipv6, &doc)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(p))
 	})


### PR DESCRIPTION
Inject the downloader so that library consumers can cache the manifest document